### PR TITLE
Freeze log4j to 2.8.2

### DIFF
--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     compile group: 'com.google.guava', name: 'guava', version: '+'
 
     // Log4J, for logging
-    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.+'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.+'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.+'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.+'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.8.2'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.8.2'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.8.2'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.8.2'
 }


### PR DESCRIPTION
because we know that version works and the newest one doesn't